### PR TITLE
Add TypeScript browser extension scaffold

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,21 @@
+# 3Lens TypeScript Extension
+
+This folder contains a minimal browser extension written in TypeScript. It demonstrates how to compile TypeScript files for use in a browser extension.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Build the extension:
+   ```bash
+   npm run build
+   ```
+   Compiled files are output to the `dist` directory.
+3. Load the extension in your browser (Chrome/Edge/Brave):
+   - Open the Extensions page and enable Developer Mode.
+   - Click "Load unpacked" and select this `extension` folder.
+   - After building, the browser will use the JavaScript files in `dist`.
+
+The background script simply logs a message when the extension is installed, and the content script logs a message on each page load.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "3Lens Extension",
+  "description": "A sample TypeScript browser extension using 3Lens.",
+  "version": "0.1.0",
+  "manifest_version": 3,
+  "background": {
+    "service_worker": "dist/background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["dist/content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "host_permissions": ["<all_urls>"]
+}

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "3lens-extension",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,0 +1,3 @@
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('3Lens extension installed');
+});

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,0 +1,1 @@
+console.log('3Lens content script loaded');

--- a/extension/src/globals.d.ts
+++ b/extension/src/globals.d.ts
@@ -1,0 +1,1 @@
+declare const chrome: any;

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "esnext",
+    "target": "es2017",
+    "lib": ["dom", "es2017"],
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add minimal TypeScript-based browser extension in `extension`
- document how to build and load the extension
- include TypeScript configuration and manifest

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_688a682adec88329b319b161f1e69e3a