### PR TITLE
feat: add overlay plugin panel support

### DIFF
--- a/packages/overlay/src/index.ts
+++ b/packages/overlay/src/index.ts
@@ -5,7 +5,12 @@
  */
 
 export { ThreeLensOverlay } from './components/Overlay';
-export type { OverlayOptions } from './components/Overlay';
+export type {
+  OverlayOptions,
+  OverlayPanelContext,
+  OverlayPanelDefinition,
+  OverlayPanelState,
+} from './components/Overlay';
 
 // Convenience function
 import type { DevtoolProbe } from '@3lens/core';
@@ -32,4 +37,3 @@ export function createOverlay(
 ): ThreeLensOverlay {
   return new ThreeLensOverlay({ probe, ...options });
 }
-


### PR DESCRIPTION
## Summary
- add overlay panel registration support with lifecycle hooks for custom plugin panels
- allow panels to be provided via overlay options or registered at runtime and expose related types

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69460bf9e9d48329915c86dd0b5973e9)