### PR TITLE
Add material builder panel scaffold

### DIFF
--- a/docs/api/overlay/create-overlay.md
+++ b/docs/api/overlay/create-overlay.md
@@ -135,6 +135,7 @@ The overlay comes with several built-in panels:
 | `scene` | Scene | Scene tree explorer and object inspector |
 | `stats` | Performance | FPS, frame time, draw calls, memory |
 | `materials` | Materials | Material browser and editor |
+| `material-builder` | Material Builder | Node-based material authoring panel |
 | `geometry` | Geometry | Geometry analysis and statistics |
 | `textures` | Textures | Texture browser with previews |
 | `render-targets` | Render Targets | Render target inspector |

--- a/packages/overlay/src/components/Overlay.ts
+++ b/packages/overlay/src/components/Overlay.ts
@@ -42,6 +42,7 @@ import {
   attachTexturesEvents,
   renderRenderTargetsPanel,
   attachRenderTargetsEvents,
+  renderMaterialBuilderPanel,
   getSharedStyles,
   createDefaultUIState,
   type UIState,
@@ -120,6 +121,14 @@ const DEFAULT_PANELS: OverlayPanelDefinition[] = [
     iconClass: 'materials',
     defaultWidth: 700,
     defaultHeight: 500,
+  },
+  {
+    id: 'material-builder',
+    title: 'Material Builder',
+    icon: '🧱',
+    iconClass: 'material-builder',
+    defaultWidth: 920,
+    defaultHeight: 560,
   },
   {
     id: 'geometry',
@@ -922,6 +931,8 @@ export class ThreeLensOverlay {
         return this.renderStatsContent();
       case 'materials':
         return this.renderMaterialsContent();
+      case 'material-builder':
+        return this.renderMaterialBuilderContent();
       case 'geometry':
         return this.renderGeometryContent();
       case 'textures':
@@ -985,6 +996,14 @@ export class ThreeLensOverlay {
   private renderMaterialsContent(): string {
     this.refreshSnapshot();
     return renderMaterialsPanel(this.buildSharedPanelContext(), this.uiState);
+  }
+
+  private renderMaterialBuilderContent(): string {
+    this.refreshSnapshot();
+    return renderMaterialBuilderPanel(
+      this.buildSharedPanelContext(),
+      this.uiState
+    );
   }
 
   private renderGeometryContent(): string {
@@ -2540,6 +2559,8 @@ export class ThreeLensOverlay {
         return this.renderStatsContent();
       case 'materials':
         return this.renderMaterialsContent();
+      case 'material-builder':
+        return this.renderMaterialBuilderContent();
       case 'geometry':
         return this.renderGeometryContent();
       case 'textures':

--- a/packages/overlay/src/styles/styles.ts
+++ b/packages/overlay/src/styles/styles.ts
@@ -305,6 +305,7 @@ export const OVERLAY_STYLES = `
 .three-lens-menu-icon.inspector { background: var(--3lens-accent-blue); color: #000; }
 .three-lens-menu-icon.textures { background: var(--3lens-accent-amber); color: #000; }
 .three-lens-menu-icon.materials { background: var(--3lens-accent-violet); color: #000; }
+.three-lens-menu-icon.material-builder { background: var(--3lens-accent-emerald); color: #000; }
 
 /* ═══════════════════════════════════════════════════════════════
    FLOATING PANELS

--- a/packages/ui/src/panels/index.ts
+++ b/packages/ui/src/panels/index.ts
@@ -9,3 +9,4 @@ export {
   renderRenderTargetsPanel,
   attachRenderTargetsEvents,
 } from './renderTargets';
+export { renderMaterialBuilderPanel } from './materialBuilder';

--- a/packages/ui/src/panels/materialBuilder.ts
+++ b/packages/ui/src/panels/materialBuilder.ts
@@ -2,7 +2,25 @@
  * Material Builder Panel - Architecture scaffold
  */
 
-import type { PanelContext, UIState } from '../types';
+      <div class="material-builder-library ${materialBuilder.isNodeLibraryOpen ? 'open' : 'collapsed'}">
+        <div class="material-builder-library-header">
+          <span>Node Library</span>
+          <button class="material-builder-toggle" data-action="material-builder-toggle-library">
+            ${materialBuilder.isNodeLibraryOpen ? 'Hide' : 'Show'}
+          </button>
+        </div>
+        <div class="material-builder-library-body">
+          <button class="material-builder-library-item" data-action="material-builder-add-node" data-node-type="texture">
+            Texture2D
+          </button>
+          <button class="material-builder-library-item" data-action="material-builder-add-node" data-node-type="value">
+            Float Value
+          </button>
+          <button class="material-builder-library-item" data-action="material-builder-add-node" data-node-type="math">
+            Math Add
+          </button>
+        </div>
+      </div>
 
 export function renderMaterialBuilderPanel(
   _context: PanelContext,
@@ -71,4 +89,71 @@ export function renderMaterialBuilderPanel(
       </div>
     </div>
   `;
+}
+  const toggleButton = container.querySelector<HTMLButtonElement>(
+    '[data-action="material-builder-toggle-library"]'
+  toggleButton?.addEventListener('click', () => {
+        isNodeLibraryOpen: !state.materialBuilder.isNodeLibraryOpen,
+  container
+    .querySelectorAll<HTMLButtonElement>(
+      '[data-action="material-builder-add-node"]'
+    )
+    .forEach((button) => {
+      button.addEventListener('click', () => {
+        const nodeType = button.dataset.nodeType ?? 'math';
+        const newNode = createNodeFromType(nodeType, state);
+        updateState({
+          materialBuilder: {
+            ...state.materialBuilder,
+            nodes: [...state.materialBuilder.nodes, newNode],
+          },
+        });
+        rerender();
+      });
+    });
+
+
+function createNodeFromType(
+  nodeType: string,
+  state: UIState
+): MaterialBuilderNode {
+  const nextIndex = state.materialBuilder.nodes.length + 1;
+  const position = { x: 120 + nextIndex * 26, y: 220 + nextIndex * 28 };
+
+  if (nodeType === 'texture') {
+    return {
+      id: `node-texture-${nextIndex}`,
+      type: 'texture',
+      title: `Texture2D ${nextIndex}`,
+      position,
+      ports: [
+        { id: 'uv', name: 'UV', direction: 'input', dataType: 'vector2' },
+        { id: 'rgba', name: 'RGBA', direction: 'output', dataType: 'color' },
+      ],
+    };
+  }
+
+  if (nodeType === 'value') {
+    return {
+      id: `node-value-${nextIndex}`,
+      type: 'value',
+      title: `Float ${nextIndex}`,
+      position,
+      ports: [
+        { id: 'value', name: 'Value', direction: 'output', dataType: 'float' },
+      ],
+    };
+  }
+
+  return {
+    id: `node-math-${nextIndex}`,
+    type: 'math',
+    title: `Add ${nextIndex}`,
+    position,
+    ports: [
+      { id: 'a', name: 'A', direction: 'input', dataType: 'float' },
+      { id: 'b', name: 'B', direction: 'input', dataType: 'float' },
+      { id: 'out', name: 'Out', direction: 'output', dataType: 'float' },
+    ],
+  };
 }

--- a/packages/ui/src/panels/materialBuilder.ts
+++ b/packages/ui/src/panels/materialBuilder.ts
@@ -1,0 +1,74 @@
+/**
+ * Material Builder Panel - Architecture scaffold
+ */
+
+import type { PanelContext, UIState } from '../types';
+
+export function renderMaterialBuilderPanel(
+  _context: PanelContext,
+  _state: UIState
+): string {
+  return `
+    <div class="panel-split-view material-builder-panel">
+      <div class="material-builder-canvas">
+        <div class="material-builder-canvas-header">
+          <div class="material-builder-title">
+            <span class="material-builder-badge">Architecture</span>
+            <span>Graph Canvas</span>
+          </div>
+          <div class="material-builder-actions">
+            <button class="material-builder-action" disabled>Add Node</button>
+            <button class="material-builder-action" disabled>Auto Layout</button>
+          </div>
+        </div>
+        <div class="material-builder-canvas-body">
+          <div class="material-builder-grid"></div>
+          <div class="material-builder-node" style="left: 72px; top: 72px;">
+            <div class="material-builder-node-header">Texture2D</div>
+            <div class="material-builder-node-body">
+              <div class="material-builder-port input">UV</div>
+              <div class="material-builder-port output">RGBA</div>
+            </div>
+          </div>
+          <div class="material-builder-node" style="left: 320px; top: 160px;">
+            <div class="material-builder-node-header">PBR Output</div>
+            <div class="material-builder-node-body">
+              <div class="material-builder-port input">Base Color</div>
+              <div class="material-builder-port input">Metalness</div>
+              <div class="material-builder-port input">Roughness</div>
+            </div>
+          </div>
+          <div class="material-builder-wire"></div>
+        </div>
+      </div>
+      <div class="panel-inspector material-builder-inspector">
+        <div class="material-builder-section">
+          <div class="material-builder-section-title">MVP Checklist</div>
+          <ul class="material-builder-checklist">
+            <li><span class="dot planned"></span> Graph canvas + pan/zoom</li>
+            <li><span class="dot planned"></span> Node library + typing rules</li>
+            <li><span class="dot planned"></span> Output node → material properties</li>
+            <li><span class="dot planned"></span> Live updates via material commands</li>
+          </ul>
+        </div>
+        <div class="material-builder-section">
+          <div class="material-builder-section-title">Selected Node</div>
+          <div class="material-builder-placeholder">Select a node to edit settings.</div>
+        </div>
+        <div class="material-builder-section">
+          <div class="material-builder-section-title">Material Output</div>
+          <div class="material-builder-output">
+            <div class="material-builder-output-row">
+              <span>Target</span>
+              <span>MeshStandardMaterial</span>
+            </div>
+            <div class="material-builder-output-row">
+              <span>Updates</span>
+              <span>Color, Roughness, Metalness</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/packages/ui/src/styles/panels.ts
+++ b/packages/ui/src/styles/panels.ts
@@ -1930,6 +1930,198 @@ export const PANEL_STYLES = `
 }
 
 /* ═══════════════════════════════════════════════════════════════
+   MATERIAL BUILDER PANEL (ARCHITECTURE)
+   ═══════════════════════════════════════════════════════════════ */
+
+.material-builder-panel {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.material-builder-canvas {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--3lens-border);
+  background: radial-gradient(circle at top left, rgba(96, 165, 250, 0.08), transparent 55%);
+}
+
+.material-builder-canvas-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--3lens-border);
+  background: var(--3lens-bg-secondary);
+}
+
+.material-builder-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.material-builder-badge {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.2);
+  color: var(--3lens-accent-blue);
+}
+
+.material-builder-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.material-builder-action {
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--3lens-border);
+  background: var(--3lens-bg-primary);
+  color: var(--3lens-text-secondary);
+  font-size: 11px;
+  cursor: not-allowed;
+}
+
+.material-builder-canvas-body {
+  position: relative;
+  flex: 1;
+  overflow: hidden;
+}
+
+.material-builder-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(transparent 23px, rgba(148, 163, 184, 0.12) 24px),
+    linear-gradient(90deg, transparent 23px, rgba(148, 163, 184, 0.12) 24px);
+  background-size: 24px 24px;
+  pointer-events: none;
+}
+
+.material-builder-node {
+  position: absolute;
+  width: 190px;
+  border-radius: 10px;
+  border: 1px solid var(--3lens-border);
+  background: var(--3lens-bg-tertiary);
+  box-shadow: var(--3lens-shadow-sm);
+}
+
+.material-builder-node-header {
+  padding: 8px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  border-bottom: 1px solid var(--3lens-border);
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.material-builder-node-body {
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  font-size: 11px;
+  color: var(--3lens-text-secondary);
+}
+
+.material-builder-port {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.material-builder-port::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--3lens-accent-cyan);
+}
+
+.material-builder-port.output::before {
+  background: var(--3lens-accent-violet);
+}
+
+.material-builder-wire {
+  position: absolute;
+  left: 220px;
+  top: 130px;
+  width: 110px;
+  height: 2px;
+  background: linear-gradient(90deg, var(--3lens-accent-cyan), var(--3lens-accent-violet));
+  box-shadow: 0 0 12px rgba(96, 165, 250, 0.4);
+}
+
+.material-builder-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+}
+
+.material-builder-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--3lens-border-subtle);
+  background: var(--3lens-bg-primary);
+}
+
+.material-builder-section-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--3lens-text-tertiary);
+}
+
+.material-builder-checklist {
+  list-style: none;
+  display: grid;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+  font-size: 12px;
+  color: var(--3lens-text-secondary);
+}
+
+.material-builder-checklist .dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 8px;
+  background: var(--3lens-border);
+}
+
+.material-builder-checklist .dot.planned {
+  background: var(--3lens-accent-amber);
+}
+
+.material-builder-placeholder {
+  color: var(--3lens-text-tertiary);
+  font-size: 12px;
+}
+
+.material-builder-output {
+  display: grid;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.material-builder-output-row {
+  display: flex;
+  justify-content: space-between;
+  color: var(--3lens-text-secondary);
+}
+
+/* ═══════════════════════════════════════════════════════════════
    SCROLLBAR
    ═══════════════════════════════════════════════════════════════ */
 

--- a/packages/ui/src/styles/panels.ts
+++ b/packages/ui/src/styles/panels.ts
@@ -1939,6 +1939,69 @@ export const PANEL_STYLES = `
   min-height: 0;
 }
 
+.material-builder-library {
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--3lens-border);
+  background: var(--3lens-bg-secondary);
+  transition: width 160ms ease;
+}
+
+.material-builder-library.collapsed {
+  width: 44px;
+}
+
+.material-builder-library-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 12px;
+  border-bottom: 1px solid var(--3lens-border);
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.material-builder-library.collapsed .material-builder-library-header span {
+  display: none;
+}
+
+.material-builder-toggle {
+  padding: 4px 8px;
+  font-size: 11px;
+  border-radius: 6px;
+  border: 1px solid var(--3lens-border);
+  background: var(--3lens-bg-primary);
+  color: var(--3lens-text-secondary);
+  cursor: pointer;
+}
+
+.material-builder-library-body {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+}
+
+.material-builder-library.collapsed .material-builder-library-body {
+  display: none;
+}
+
+.material-builder-library-item {
+  padding: 8px 10px;
+  text-align: left;
+  border-radius: 8px;
+  border: 1px solid var(--3lens-border);
+  background: var(--3lens-bg-primary);
+  color: var(--3lens-text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.material-builder-library-item:hover {
+  background: var(--3lens-bg-hover);
+  color: var(--3lens-text-primary);
+}
+
 .material-builder-canvas {
   flex: 1;
   display: flex;

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -43,6 +43,7 @@ export type PanelCommand =
   | { type: 'geometry-visualization'; geometryUuid: string; visualization: 'boundingBox' | 'wireframe' | 'normals'; enabled: boolean };
 
 /**
+  isNodeLibraryOpen: boolean;
  * State managed by the UI system
  */
 export interface UIState {
@@ -132,3 +133,4 @@ export type PanelEventAttacher = (
 // Re-export types from core for convenience
 export type { SceneSnapshot, SceneNode, FrameStats, MaterialData, GeometryData, TextureData, RenderTargetData, BenchmarkScore };
 
+      isNodeLibraryOpen: true,


### PR DESCRIPTION
### Motivation

- Provide an initial architecture and UI scaffold for a node-based Material Builder to enable iterative implementation of graph-based material authoring.
- Surface the new panel inside the existing floating overlay so it can be previewed and iterated alongside other devtools panels.
- Keep styles and shared UI patterns consistent with other panels by using the existing `@3lens/ui` panel layout and theme variables.
- Document the new built-in panel so it appears in the overlay API docs and menu.

### Description

- Add a new renderer `renderMaterialBuilderPanel` in `packages/ui/src/panels/materialBuilder.ts` that returns a graph-canvas placeholder and inspector layout.
- Export the new renderer from `packages/ui/src/panels/index.ts` and add scoped panel styles in `packages/ui/src/styles/panels.ts` under a `material-builder` section.
- Register the new `material-builder` panel in the overlay `DEFAULT_PANELS` and wire rendering via `renderMaterialBuilderContent()` in `packages/overlay/src/components/Overlay.ts`, plus add a menu icon color in `packages/overlay/src/styles/styles.ts`.
- Add the panel to the built-in panels table in `docs/api/overlay/create-overlay.md` so it is documented.

### Testing

- Ran the formatting task `oxfmt` as part of the pre-commit hooks and it completed successfully.
- Ran the linter `oxlint` with flags `-A no-unused-vars -A no-unassigned-vars -A unicorn/no-new-array -A unicorn/no-useless-spread -A unicorn/no-useless-fallback-in-spread` and it completed successfully.
- Commit hooks ran and applied the formatting/lint modifications during the commit process and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69658f18c1f4832997c33bab571bcc03)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Material Builder panel to the overlay with a split canvas/inspector interface and interactive node tools.
* **Documentation**
  * Overlay docs updated to list the Material Builder in the built-in panels table.
* **Styles**
  * New styling for the Material Builder UI and a menu icon color variant for the panel.
* **Public API / Types**
  * Exposed Material Builder panel renderer and added a UI state flag for node library visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->