### PR TITLE
security: gate postMessage transport in production

### DIFF
--- a/docs/api/core/create-probe.md
+++ b/docs/api/core/create-probe.md
@@ -280,7 +280,7 @@ const probe = createProbe({
 
 ## Auto-Connection
 
-When running in a browser environment, `createProbe()` automatically establishes a connection to the 3Lens browser extension via `postMessage` transport. This enables:
+When running in a browser environment, `createProbe()` automatically establishes a connection to the 3Lens browser extension via `postMessage` transport (except in production unless explicitly enabled). This enables:
 
 - Automatic detection by the browser extension
 - Zero-configuration extension integration
@@ -289,6 +289,13 @@ When running in a browser environment, `createProbe()` automatically establishes
 ```typescript
 // The probe auto-connects - no manual setup needed!
 const probe = createProbe({ appName: 'My App' });
+
+// In production, opt in explicitly to allow postMessage transport
+const productionProbe = createProbe({
+  appName: 'My App',
+  env: 'production',
+  allowPostMessageTransport: true,
+});
 
 // The browser extension will automatically discover this probe
 ```

--- a/docs/api/core/probe-lifecycle.md
+++ b/docs/api/core/probe-lifecycle.md
@@ -73,11 +73,16 @@ constructor(config: ProbeConfig) {
 
 ### Auto-Connection (createProbe only)
 
-The `createProbe()` factory automatically establishes a connection:
+The `createProbe()` factory automatically establishes a connection (except in production unless explicitly enabled):
 
 ```typescript
 // In createProbe():
-if (typeof window !== 'undefined' && typeof window.postMessage === 'function') {
+const env = config.env ?? 'development';
+if (
+  typeof window !== 'undefined' &&
+  typeof window.postMessage === 'function' &&
+  (env !== 'production' || config.allowPostMessageTransport === true)
+) {
   const transport = createPostMessageTransport();
   probe.connect(transport);
 }

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -55,6 +55,20 @@ const probe = createProbe({
 Enable debug mode temporarily when 3Lens isn't behaving as expected. The logs show exactly what's being observed and sampled.
 :::
 
+### `allowPostMessageTransport`
+
+**Type:** `boolean`  
+**Default:** `false` when `env` is `'production'`, otherwise `true`
+
+Controls whether `createProbe()` auto-connects to the browser extension via the `postMessage` transport. Keep this disabled in production to prevent untrusted scripts from talking to the probe over same-origin messaging.
+
+```typescript
+const probe = createProbe({
+  env: 'production',
+  allowPostMessageTransport: false,
+});
+```
+
 ### `autoConnect`
 
 **Type:** `boolean`  

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -89,6 +89,8 @@ interface ProbeConfig {
   appName: string;
   env?: 'development' | 'staging' | 'production';
   debug?: boolean;
+  // Allow auto postMessage transport in production (default false).
+  allowPostMessageTransport?: boolean;
   rules?: {
     maxDrawCalls?: number;
     maxTriangles?: number;
@@ -101,4 +103,3 @@ interface ProbeConfig {
 ## License
 
 MIT
-

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -171,10 +171,7 @@ export type {
  * Transport types for communication with browser extensions.
  * @category Transport
  */
-export type {
-  Transport,
-  DebugMessage,
-} from './types/transport';
+export type { Transport, DebugMessage } from './types/transport';
 
 /**
  * Common utility types.
@@ -194,7 +191,8 @@ export { DevtoolProbe, PROBE_VERSION } from './probe/DevtoolProbe';
 
 /**
  * Factory function to create a configured DevtoolProbe instance.
- * Automatically sets up postMessage transport for browser extension integration.
+ * Automatically sets up postMessage transport for browser extension integration
+ * (disabled by default in production unless explicitly enabled).
  * @category Core
  */
 export { createProbe } from './probe/createProbe';
@@ -242,10 +240,7 @@ export { CameraController } from './helpers/CameraController';
  * Camera controller types.
  * @category Helpers
  */
-export type {
-  CameraInfo,
-  FlyToOptions,
-} from './helpers/CameraController';
+export type { CameraInfo, FlyToOptions } from './helpers/CameraController';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // TRACKING - Resource Lifecycle & Memory
@@ -283,7 +278,11 @@ export type {
  * Configuration loader and rule checker.
  * @category Configuration
  */
-export { ConfigLoader, DEFAULT_THRESHOLDS, DEFAULT_SAMPLING } from './config/ConfigLoader';
+export {
+  ConfigLoader,
+  DEFAULT_THRESHOLDS,
+  DEFAULT_SAMPLING,
+} from './config/ConfigLoader';
 
 /**
  * Configuration and rule checking types.
@@ -368,7 +367,12 @@ export type {
  * Built-in plugins for common debugging tasks.
  * @category Plugins
  */
-export { LODCheckerPlugin, ShadowDebuggerPlugin, BUILTIN_PLUGINS, getBuiltinPlugins } from './plugins';
+export {
+  LODCheckerPlugin,
+  ShadowDebuggerPlugin,
+  BUILTIN_PLUGINS,
+  getBuiltinPlugins,
+} from './plugins';
 
 /**
  * Built-in plugin types.
@@ -403,7 +407,12 @@ export type { WebGLAdapterOptions } from './adapters/webgl-adapter';
  * WebGPU renderer adapter factory and utilities.
  * @category Adapters
  */
-export { createWebGPUAdapter, createExtendedWebGPUAdapter, isWebGPURenderer, getWebGPUCapabilities } from './adapters/webgpu-adapter';
+export {
+  createWebGPUAdapter,
+  createExtendedWebGPUAdapter,
+  isWebGPURenderer,
+  getWebGPUCapabilities,
+} from './adapters/webgpu-adapter';
 
 /**
  * WebGPU adapter types.
@@ -423,7 +432,11 @@ export type {
  * WebGPU GPU timing utilities.
  * @category Adapters
  */
-export { WebGpuTimingManager, createTimestampWrites, categorizePass } from './adapters/webgpu-timing';
+export {
+  WebGpuTimingManager,
+  createTimestampWrites,
+  categorizePass,
+} from './adapters/webgpu-timing';
 
 /**
  * WebGPU timing types.

--- a/packages/core/src/probe/createProbe.ts
+++ b/packages/core/src/probe/createProbe.ts
@@ -26,12 +26,14 @@ import { createPostMessageTransport } from '../transport/postmessage-transport';
  */
 export function createProbe(config: ProbeConfig): DevtoolProbe {
   const probe = new DevtoolProbe(config);
+  const env = config.env ?? 'development';
 
   // Auto-connect to browser extension via postMessage transport
   // This enables the Chrome extension to work without manual setup
   if (
     typeof window !== 'undefined' &&
-    typeof window.postMessage === 'function'
+    typeof window.postMessage === 'function' &&
+    (env !== 'production' || config.allowPostMessageTransport === true)
   ) {
     const transport = createPostMessageTransport();
     probe.connect(transport);

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -35,6 +35,12 @@ export interface ProbeConfig {
    * @default false
    */
   debug?: boolean;
+
+  /**
+   * Allow automatic postMessage transport in production environments.
+   * Defaults to false when env is 'production'.
+   */
+  allowPostMessageTransport?: boolean;
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Prevent automatic exposure of the probe to same-origin `postMessage` connections in production builds to avoid untrusted scripts from interacting with the probe.
- Make the auto-connection behavior explicit so production users must opt in to cross-context transport.

### Description
- Add a runtime guard in `createProbe()` to only auto-connect the `postMessage` transport when `env !== 'production'` or `allowPostMessageTransport` is explicitly set to `true`.
- Introduce the new `ProbeConfig` option `allowPostMessageTransport?: boolean` and update `packages/core/src/types/config.ts` and `packages/core/README.md` to document it.
- Update docs and API pages (e.g. `docs/guide/configuration.md`, `docs/api/core/create-probe.md`, `docs/api/core/probe-lifecycle.md`) to clarify the production-safe behavior and show how to opt in.
- Add a short note to the public index doc comment to indicate the postMessage transport is disabled by default in production unless enabled.

### Testing
- Ran code formatting via `oxfmt`, which completed successfully.
- Ran linting checks via `oxlint` with permissive flags used in pre-commit, which completed successfully.
- Pre-commit tasks (format + lint) completed and the changes were committed without errors.
- No unit or integration test suites were executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69659751b6048329ba2e819377df9af5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `allowPostMessageTransport` configuration option to control browser extension auto-connection via postMessage transport.

* **Improvements**
  * postMessage transport now defaults to disabled in production environments for enhanced security. Can be explicitly enabled via configuration when needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->